### PR TITLE
Fix malformed dates breaking everything

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -11,8 +11,7 @@ def scrape_table(agent, scrape_url, comment_url)
   doc = agent.get(scrape_url)
   rows = doc.search('.inputField').map { |e| e.inner_text.strip }
   reference = rows[2]
-  date_received = Date.strptime(rows[3], '%d/%m/%Y').to_s rescue ni
-l
+  date_received = Date.strptime(rows[3], '%d/%m/%Y').to_s rescue nil
   puts "Invalid date: #{rows[3].inspect}" unless date_received
 
   record = {

--- a/scraper.rb
+++ b/scraper.rb
@@ -9,7 +9,7 @@ search_result_url = 'https://ecouncil.burwood.nsw.gov.au/eservice/daEnquiryDetai
 def scrape_table(agent, scrape_url, comment_url)
   puts "Scraping " + scrape_url
   doc = agent.get(scrape_url)
-  rows = doc.search('.inputField').map { |e| e.inner_text.strip }
+  rows = doc.search('.rowDataOnly > .inputField:nth-child(2)').map { |e| e.inner_text.strip }
   reference = rows[2]
   date_received = Date.strptime(rows[3], '%d/%m/%Y').to_s rescue nil
   puts "Invalid date: #{rows[3].inspect}" unless date_received

--- a/scraper.rb
+++ b/scraper.rb
@@ -11,11 +11,15 @@ def scrape_table(agent, scrape_url, comment_url)
   doc = agent.get(scrape_url)
   rows = doc.search('.inputField').map { |e| e.inner_text.strip }
   reference = rows[2]
+  date_received = Date.strptime(rows[3], '%d/%m/%Y').to_s rescue ni
+l
+  puts "Invalid date: #{rows[3].inspect}" unless date_received
+
   record = {
     'info_url' => "https://ecouncil.burwood.nsw.gov.au/eservice/daEnquiryInit.do?doc_typ=10&nodeNum=219",
     'comment_url' => comment_url + CGI::escape("Development Application Enquiry: " + reference),
     'council_reference' => reference,
-    'date_received' => Date.strptime(rows[3], '%d/%m/%Y').to_s,
+    'date_received' => date_received,
     'address' => rows[0],
     'description' => rows[1],
     'date_scraped' => Date.today.to_s


### PR DESCRIPTION
```
Scraping https://ecouncil.burwood.nsw.gov.au/eservice/daEnquiryDetails.do?index=2
 scraper.rb:18:in `strptime' : invalid date (ArgumentError)
    from scraper.rb:18:in `scrape_table'
    from scraper.rb:37:in `block in <main>'
    from scraper.rb:35:in `each'
    from scraper.rb:35:in `<main>'
```

Untested on my local properly though, due to their use of TLS 1.0 certs :(
